### PR TITLE
Add unrecognized creators

### DIFF
--- a/typeMap.json
+++ b/typeMap.json
@@ -72,6 +72,51 @@
                     "#tail": "  ",
                     "@cslField": "translator",
                     "@zField": "translator"
+                },
+                {
+                    "#tail": "  ",
+                    "@cslField": "author",
+                    "@zField": "interviewee"
+                },
+                {
+                    "#tail": "  ",
+                    "@cslField": "author",
+                    "@zField": "artist"
+                },
+                {
+                    "#tail": "  ",
+                    "@cslField": "author",
+                    "@zField": "sponsor"
+                },
+                {
+                    "#tail": "  ",
+                    "@cslField": "author",
+                    "@zField": "inventor"
+                },
+                {
+                    "#tail": "  ",
+                    "@cslField": "author",
+                    "@zField": "cartographer"
+                },
+                {
+                    "#tail": "  ",
+                    "@cslField": "author",
+                    "@zField": "performer"
+                },
+                {
+                    "#tail": "  ",
+                    "@cslField": "author",
+                    "@zField": "presenter"
+                },
+                {
+                    "#tail": "  ",
+                    "@cslField": "author",
+                    "@zField": "podcaster"
+                },
+                {
+                    "#tail": "  ",
+                    "@cslField": "author",
+                    "@zField": "programmer"
                 }
             ]
         },
@@ -2221,7 +2266,7 @@
                             "creatorType": [
                                 {
                                     "#tail": "        ",
-                                    "@baseField": "author",
+                                    "@baseField": "director",
                                     "@label": "Director",
                                     "@value": "director"
                                 },
@@ -3971,7 +4016,7 @@
                             "creatorType": [
                                 {
                                     "#tail": "        ",
-                                    "@baseField": "author",
+                                    "@baseField": "director",
                                     "@label": "Director",
                                     "@value": "director"
                                 },
@@ -4111,7 +4156,7 @@
                             "creatorType": [
                                 {
                                     "#tail": "        ",
-                                    "@baseField": "author",
+                                    "@baseField": "director",
                                     "@label": "Director",
                                     "@value": "director"
                                 },
@@ -4256,7 +4301,7 @@
                             "creatorType": [
                                 {
                                     "#tail": "        ",
-                                    "@baseField": "author",
+                                    "@baseField": "director",
                                     "@label": "Director",
                                     "@value": "director"
                                 },


### PR DESCRIPTION
Several creators not set in the general map of creator variables were being set as "null" rather than as their CSL variable name. With this pull request they will be recognized. The pull request also sets "director" as a direct mapping everywhere, since it is a first-class creator variable in CSL 1.0.1.